### PR TITLE
Adding board support for LILYGO T-Deck

### DIFF
--- a/Boardfiles/lilygo_tdeck/boot.txt
+++ b/Boardfiles/lilygo_tdeck/boot.txt
@@ -1,0 +1,6 @@
+00-gpio.py
+01-early-connection.py
+02-LEDs.py
+03-reload-hostname.py
+04-networking.lja
+05-advance-time.lja

--- a/Boardfiles/lilygo_tdeck/drivers.txt
+++ b/Boardfiles/lilygo_tdeck/drivers.txt
@@ -1,0 +1,3 @@
+driver_wifi
+gpiochip
+displayiotty

--- a/Boardfiles/lilygo_tdeck/packages.txt
+++ b/Boardfiles/lilygo_tdeck/packages.txt
@@ -1,0 +1,15 @@
+sysinfo
+ducky
+ed
+ftpd
+hashutils
+jpkg
+less
+nano
+neofetch
+netutils
+wget
+lm_sensors
+uartutils
+i2ctools
+adctools

--- a/Boardfiles/lilygo_tdeck/pinout.map
+++ b/Boardfiles/lilygo_tdeck/pinout.map
@@ -1,0 +1,10 @@
+[No board view available]
+
+LILYGO T-Deck
+
+SoC                : ESP32-S3
+RAM                : 8704KB
+Storage            : DIO (16MB)
+Wi-fi              : True
+Bluetooth          : True
+

--- a/Boardfiles/lilygo_tdeck/settings.toml
+++ b/Boardfiles/lilygo_tdeck/settings.toml
@@ -1,0 +1,30 @@
+CIRCUITPY_PYSTACK_SIZE = 12288
+
+[BERYLLIUM]
+setup = true
+
+fs_label = "BERYLLIUM"
+
+serial_console_enabled = true
+usb_msc_available = false
+usb_hid_available = false
+usb_midi_available = false
+wifi_available = true
+ble_available = false
+blc_available = false
+usb_msc_enabled = false
+usb_hid_enabled = false
+usb_midi_enabled = false
+
+ledtype = "none"
+led = "none"
+
+DEBUG = false
+
+[IWD]
+#Network1 = "password1"
+#Network2 = "password2"
+
+[IWD-AP]
+SSID = "beryllium-ap"
+PASSWD = "CHANGEME WIFI PASSWORD"

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Espressif:<br />
  - AiThinker ESP32-CAM<br />
  - DFRobot Beetle ESP32-C3<br />
  - Firebeetle 2 ESP32-S3<br />
+ - LILYGO T-Deck<br />
  - M5Stack Cardputer (Requires 9.1.0-beta1 or later)<br />
  - M5Stack Timer Camera X<br />
  - MakerGo C3 Supertiny<br />


### PR DESCRIPTION
Works well over a serial connection.

![Beryllium running on LILYGO T-Deck](https://github.com/user-attachments/assets/1683003d-abb7-4e71-bced-24edf39d1566)
